### PR TITLE
Allow user to specify an endpoint other than '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,18 @@ window.flingerAdditionalClientData = function () {
 Want to format your messages:
 ```javascript
 window.flingerFormatter = function(x){
-	return "Your Format Here!";
+  return "Your Format Here!";
 }
 ```
+
+Want to post to a different endpoint or have a server that doesn't live at '/'
+```html
+<script>
+  window.flingerURL("http://www.domain.com/endpoint");
+</script>
+```
+To disable posting to server, set `flingerURL` to an empty string.
+
 
 You can do this anywhere you like client side. Yep, it's a global
 function, but did we mention that we're monkey patching console.log to
@@ -125,4 +134,3 @@ flinger_handler.augmentLog = function (logArguments,request) {
 // now register this handler with the middleware stack
 app.use(flinger_handler);
 </code></pre>
-

--- a/client.js
+++ b/client.js
@@ -3,11 +3,17 @@
  */
 ;
 (function () {
+  var flingerURL='/';
   window.flingerAdditionalClientData = function () {
     return "";
   }
 
   window.flingerFormatter = function (x) {
+    return x.toLocaleString();
+  }
+
+  window.flingerURL = function (x) {
+    flingerURL=x;
     return x.toLocaleString();
   }
 
@@ -44,12 +50,14 @@
   }
   //send along to the server
   var send = debounce(function(){
-    jQuery.ajax({
-      type: "POST",
-      url: "/",
-      contentType: 'application/flinger',
-      data: JSON.stringify(sendBuffer)
-    });
+    if (flingerURL && flingerURL.length) {
+        jQuery.ajax({
+        type: "POST",
+        url: flingerURL,
+        contentType: 'application/flinger',
+        data: JSON.stringify(sendBuffer)
+      });
+    }
     sendBuffer = [];
   }, 1000);
   //ancient browsers may lack a console

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flinger",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Flinger flings logs from your browser clients back to your node servers so you can see what your users are up to.",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Defaults the endpoint to ‘/‘ but the user can override it.
Taken from @skukkonen
https://github.com/glg/starflinger